### PR TITLE
Issue SSL when CERTBOT_SG not defined (issue #18)

### DIFF
--- a/alyx/containers/docker/scripts/alyx_issue_ssl.sh
+++ b/alyx/containers/docker/scripts/alyx_issue_ssl.sh
@@ -28,18 +28,17 @@ if [ ! -f /etc/letsencrypt/live/$APACHE_SERVER_NAME/fullchain.pem ] || [ ! -f /e
         -out /etc/letsencrypt/live/$APACHE_SERVER_NAME/fullchain.pem \
         -subj "/C=GB/ST=London/L=London/O=IBL/OU=IT/CN=${APACHE_SERVER_NAME}" &&
 
+    echo "Attempting to issue certificates for $APACHE_SERVER_NAME"
+    # Start apache server
+    apache2ctl start
     if [ -n "$CERTBOT_SG" ]; then
-        # Start apache server
-        echo "Attempting to renew certificates for $APACHE_SERVER_NAME"
-        apache2ctl start
         rm -rf /etc/letsencrypt/live/$APACHE_SERVER_NAME
-
         # Generate a new SSL certificate using certbot
         /bin/bash /home/iblalyx/crons/renew_docker_certs.sh  # TODO issue flag for this script
-
-        # Restart apache server to apply the new certificate (NB: server started by docker-compose)
-        apache2ctl stop
-    # TODO: else statement for simple issuing where no security group is provided
+    else
+        certbot --apache --noninteractive --agree-tos --email $APACHE_SERVER_ADMIN -d $APACHE_SERVER_NAME
     fi
+    # Restart apache server to apply the new certificate (NB: server started by docker-compose)
+    apache2ctl stop
 
 fi

--- a/alyx/hosts/alyx-test/02_renew_certificate.sh
+++ b/alyx/hosts/alyx-test/02_renew_certificate.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-set -e
-docker exec -it alyx_apache certbot --apache --noninteractive --agree-tos --email admin@internationalbrainlab.org -d test.alyx.internationalbrainlab.org

--- a/alyx/hosts/alyx-test/crontab.cron
+++ b/alyx/hosts/alyx-test/crontab.cron
@@ -2,4 +2,4 @@
 15 23 * * * ~/Documents/PYTHON/iblsre/alyx/hosts/alyx-test/00_rebuild_from_cache.sh > /var/log/alyx/00_rebuild_from_cache.log
 
 # every 2 months
-0 0 1 */2 * ~/Documents/PYTHON/iblsre/alyx/hosts/alyx-test/02_renew_certificate.sh > /var/log/alyx/02_renew_certificate.log
+0 0 1 */2 * docker exec -it alyx_apache bash -c "certbot renew --apache 2>&1 | tee /var/log/certbot-renew.log"


### PR DESCRIPTION
Certificate renewal cron now works on Steinmetzlab and test alyx after removing old certbot conf file (see related issue). Changes to [alyx_issue_ssl.sh](https://github.com/int-brain-lab/iblsre/compare/certbotRenew?expand=1#diff-f35f47c0745d725805a6068ed022c6c655436366939dd5b72f762f6b24193a9e) haven't been tested.