### PR TITLE
Cap apache container memory and dataset pagination limit

### DIFF
--- a/alyx/containers/deploy-web/docker-compose.yaml
+++ b/alyx/containers/deploy-web/docker-compose.yaml
@@ -2,6 +2,8 @@ services:
   alyx_apache:
     image: internationalbrainlab/alyx_apache:latest
     container_name: alyx_apache
+    mem_limit: ${APACHE_MEM_LIMIT:-1500m}
+    memswap_limit: ${APACHE_MEM_LIMIT:-1500m}
     ports:
       - "8080:8080"
       - "443:443"

--- a/alyx/containers/deploy-web/template.env
+++ b/alyx/containers/deploy-web/template.env
@@ -16,3 +16,4 @@ DJANGO_TABLES_ROOT=~/tables
 # DJANGO_TABLES_ROOT=~/scratch/uploaded # add if local storage
 # DJANGO_MEDIA_S3=https://alyx-uploaded.s3.eu-west-2.amazonaws.com/uploaded/  # add if s3 (will override local media)
 # DJANGO_TABLES_S3=https://ibl-brain-wide-map-public.s3.amazonaws.com/caches/alyx  # add if s3 (will override local media)
+# APACHE_MEM_LIMIT=1500m  # cap apache container memory (defaults to 1500m if unset)

--- a/alyx/containers/docker/alyx-settings/settings-deploy.py
+++ b/alyx/containers/docker/alyx-settings/settings-deploy.py
@@ -205,7 +205,7 @@ REST_FRAMEWORK = {
     },
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
     'STRICT_JSON': False,
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'DEFAULT_PAGINATION_CLASS': 'alyx.base.LimitedLimitOffsetPagination',
     'EXCEPTION_HANDLER': 'alyx.base.rest_filters_exception_handler',
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'PAGE_SIZE': 250,


### PR DESCRIPTION
Deployment-side changes to prevent a repeat of the openalyx OOM outage: caps `alyx_apache`'s memory via `mem_limit`/`memswap_limit` (default 1500m, override with `APACHE_MEM_LIMIT`), and mirrors the `DEFAULT_PAGINATION_CLASS` fix from cortex-lab/alyx#1013 in the baked-in `settings-deploy.py`.

Fixes int-brain-lab/iblalyx#151