### PR TITLE
Recycle WSGI daemon process on timeout/request count

### DIFF
--- a/alyx/containers/docker/apache-conf/alyx-common.conf
+++ b/alyx/containers/docker/apache-conf/alyx-common.conf
@@ -27,7 +27,7 @@ ErrorLog ${APACHE_LOG_DIR}/error_alyx.log
 CustomLog ${APACHE_LOG_DIR}/access_alyx.log combined
 
 WSGIApplicationGroup %{GLOBAL}
-WSGIDaemonProcess alyx python-path=/var/www/alyx/alyx python-home=/var/www/alyx/.venv socket-user=#33 listen-backlog=50
+WSGIDaemonProcess alyx python-path=/var/www/alyx/alyx python-home=/var/www/alyx/.venv socket-user=#33 listen-backlog=50 request-timeout=300 maximum-requests=1000
 WSGIProcessGroup alyx
 WSGIScriptAlias / /var/www/alyx/alyx/alyx/wsgi.py
 WSGIPassAuthorization On


### PR DESCRIPTION
Adds `request-timeout=300` and `maximum-requests=1000` to the `WSGIDaemonProcess` directive, so a stuck or leaking worker gets reaped instead of running the host out of memory.

Fixes int-brain-lab/iblalyx#151