### PR TITLE
Add idempotent 2GB swapfile provisioning to server setup

### DIFF
--- a/alyx/ansible/ansible_setup_alyx_server.yaml
+++ b/alyx/ansible/ansible_setup_alyx_server.yaml
@@ -45,6 +45,39 @@
       args:
         creates: /home/ubuntu/spacer.bin
 
+    - name: Create 2GB swapfile
+      command: fallocate -l 2G /swapfile
+      args:
+        creates: /swapfile
+
+    - name: Set swapfile permissions
+      file:
+        path: /swapfile
+        mode: '0600'
+
+    - name: Format swapfile
+      command: mkswap /swapfile
+      when: ansible_swaptotal_mb == 0
+
+    - name: Enable swapfile
+      command: swapon /swapfile
+      when: ansible_swaptotal_mb == 0
+
+    - name: Persist swapfile in fstab
+      mount:
+        path: none
+        src: /swapfile
+        fstype: swap
+        opts: sw
+        state: present
+
+    - name: Set vm.swappiness for emergency-only swap use
+      sysctl:
+        name: vm.swappiness
+        value: '10'
+        state: present
+        reload: yes
+
     - name: Ensure log directory exists
       file:
         path: "{{ log_dir }}"


### PR DESCRIPTION
Adds a 2GB swapfile + vm.swappiness=10 to the "Prepare Linux instance for Alyx" play, so a host degrades gracefully under memory pressure instead of hanging. Guarded (`creates:`, `ansible_swaptotal_mb == 0`) so it's safe to re-run against already-provisioned hosts (openalyx, alyx-prod, test.alyx, cazettes), not just fresh ones.

Fixes int-brain-lab/iblalyx#151