### PR TITLE
Host per-server Alyx compose overrides in iblsre (C4)

### DIFF
--- a/alyx/containers/deploy-web/docker-compose.override.yaml
+++ b/alyx/containers/deploy-web/docker-compose.override.yaml
@@ -1,0 +1,20 @@
+# IBL-specific overlay on top of the generic alyx base compose (cortex-lab/alyx
+# deploy/app/docker-compose.yaml). Re-adds the iblalyx pieces that were removed from
+# the base compose so it stays server-agnostic. Apply with:
+#   docker compose -f <alyx>/deploy/app/docker-compose.yaml -f docker-compose.override.yaml up -d
+#
+# `command` fully replaces the base command (compose does not merge it), so it repeats
+# the base steps and prepends the iblalyx requirements install. The iblalyx/ibl_reports
+# volumes are appended to the base volume list.
+services:
+  alyx_apache:
+    command: >
+      bash -c "pip install --no-cache-dir -r /home/iblalyx/requirements.txt &&
+               python /var/www/alyx/alyx/manage.py collectstatic --noinput &&
+               /bin/bash /usr/local/bin/alyx_issue_ssl.sh &&
+               chown www-data:www-data -fR /var/log/apache2 &&
+               /usr/sbin/apache2ctl -DFOREGROUND"
+    volumes:
+      - ${IBLALYX_ROOT:-/home/ubuntu/iblalyx}:/home/iblalyx
+      - ${IBLALYX_ROOT:-/home/ubuntu/iblalyx}/management/ibl_reports:/var/www/alyx/alyx/ibl_reports
+      - ${IBLALYX_ROOT:-/home/ubuntu/iblalyx}/management/ibl_reports/templates:/var/www/alyx/alyx/templates/ibl_reports

--- a/alyx/hosts/cortexlab/docker-compose.override.yaml
+++ b/alyx/hosts/cortexlab/docker-compose.override.yaml
@@ -1,0 +1,20 @@
+# Cortexlab overlay on top of the generic alyx base compose
+# (cortex-lab/alyx deploy/app/docker-compose.yaml).
+#
+# Differences from the base:
+#   - installs django_ses (email via AWS SES) at startup;
+#   - mounts the lab-specific settings_lab.py (kept sops-encrypted in the private
+#     ibldevtools/config/alyx-cortexlab/; decrypt it to ALYX_SETTINGS_LAB on the host).
+#
+# `command` fully replaces the base command (compose does not merge it), so it repeats
+# the base steps with the django_ses install prepended.
+services:
+  alyx_apache:
+    command: >
+      bash -c "pip install django_ses &&
+               python /var/www/alyx/alyx/manage.py collectstatic --noinput &&
+               /bin/bash /usr/local/bin/alyx_issue_ssl.sh &&
+               chown www-data:www-data -fR /var/log/apache2 &&
+               /usr/sbin/apache2ctl -DFOREGROUND"
+    volumes:
+      - ${ALYX_SETTINGS_LAB:-/home/ubuntu/settings_lab.py}:/var/www/alyx/alyx/alyx/settings_lab.py:ro

--- a/alyx/hosts/steinmetzlab/docker-compose.override.yaml
+++ b/alyx/hosts/steinmetzlab/docker-compose.override.yaml
@@ -1,0 +1,10 @@
+# Steinmetzlab overlay on top of the generic alyx base compose
+# (cortex-lab/alyx deploy/app/docker-compose.yaml).
+#
+# Only difference from the base: mounts the lab-specific settings_lab.py (kept
+# sops-encrypted in the private ibldevtools/config/alyx-steinmetzlab/; decrypt it to
+# ALYX_SETTINGS_LAB on the host). Inherits the base startup command unchanged.
+services:
+  alyx_apache:
+    volumes:
+      - ${ALYX_SETTINGS_LAB:-/home/ubuntu/settings_lab.py}:/var/www/alyx/alyx/alyx/settings_lab.py:ro


### PR DESCRIPTION
Part of the Alyx container de-duplication (iblalyx #152, Phase C4).

Moves the per-server docker-compose overrides out of the private `ibldevtools/config` and version-controls them here, so iblsre owns deploy orchestration:

- `alyx/hosts/cortexlab/docker-compose.override.yaml` — django_ses install + settings_lab.py mount
- `alyx/hosts/steinmetzlab/docker-compose.override.yaml` — settings_lab.py mount
- `alyx/containers/deploy-web/docker-compose.override.yaml` — IBL iblalyx overlay (requirements install + ibl_reports mounts) on top of the now server-agnostic base compose

`settings_lab.py` stays sops-encrypted in the private ibldevtools (it is not committed to this public repo); it is decrypted onto the host at deploy time and referenced via `ALYX_SETTINGS_LAB` (default `/home/ubuntu/settings_lab.py`).

All override commands drop the stray `chown ... 664` arg and use `&&` before apache, matching the fixed base command in cortex-lab/alyx.

The matching removal of the override files from ibldevtools/config and the dev-site doc update are done in the ibldevtools repo.