### PR TITLE
Persist alyx-test cache tables (iblalyx#153)

### DIFF
--- a/alyx/hosts/alyx-test/docker-compose.override.yaml
+++ b/alyx/hosts/alyx-test/docker-compose.override.yaml
@@ -1,0 +1,27 @@
+# alyx-test (test.alyx.internationalbrainlab.org) host overlay.
+#
+# alyx-test is an IBL server that serves ibl_reports, so it needs the iblalyx overlay
+# on top of the generic base compose. This file only adds the host-specific persistent
+# mounts; the iblalyx command + bind-mounts come from the shared overlay. Deploy by
+# stacking all three, base first:
+#
+#   docker compose \
+#     -f <alyx>/deploy/app/docker-compose.yaml \
+#     -f <iblsre>/alyx/containers/deploy-web/docker-compose.override.yaml \
+#     -f <iblsre>/alyx/hosts/alyx-test/docker-compose.override.yaml \
+#     up -d
+#
+# Requires iblalyx cloned on the host (ansible_setup_alyx_server.yaml does this, to
+# /home/ubuntu/iblalyx) so the overlay's bind-mount has a source.
+#
+# Persistent host dirs (created by ansible_setup_alyx_server.yaml):
+#   - /home/ubuntu/uploaded  -> media (uploaded files)                also in the base compose
+#   - /home/ubuntu/tables    -> ONE aggregate cache tables (DJANGO_TABLES_ROOT in .env)
+# The tables mount is the one alyx-test-specific piece missing from the base: .env sets
+# DJANGO_TABLES_ROOT=/var/www/alyx/alyx/tables but nothing persists it, so the cache
+# (datasets.pqt/sessions.pqt/cache.zip) is otherwise lost on every container restart.
+services:
+  alyx_apache:
+    volumes:
+      - ${DJANGO_MEDIA_ROOT:-/home/ubuntu/uploaded}:/var/www/alyx/alyx/uploaded
+      - ${ALYX_TABLES_ROOT:-/home/ubuntu/tables}:/var/www/alyx/alyx/tables


### PR DESCRIPTION
Fixes int-brain-lab/iblalyx#153 — the test instance lost its cache tables.

alyx-test (`test.alyx.internationalbrainlab.org`) serves ibl_reports, so it stacks the iblalyx overlay on the base compose. This adds `alyx/hosts/alyx-test/docker-compose.override.yaml` with the host-specific persistent mounts:

- `/home/ubuntu/uploaded` → media
- `/home/ubuntu/tables` → `/var/www/alyx/alyx/tables` (the ONE aggregate cache; `DJANGO_TABLES_ROOT` in .env)

Root cause: the live deployment set `DJANGO_TABLES_ROOT` but never mounted a host `tables` dir, so the cache (`datasets.pqt`/`sessions.pqt`/`cache.zip`) was written to the container's ephemeral layer and lost on every restart.

Deploy stacks three files (base + iblalyx overlay + this host override); verified with `docker compose config`. First deploy off the new image also needs `ansible_setup_alyx_server.yaml` run on the host (clones iblalyx to /home/ubuntu/iblalyx for the overlay's bind-mount).

Note: cross-repo closing keywords don't auto-close, so iblalyx#153 will be closed manually on merge.