### PR TITLE
Ansible-driven Alyx deploy from ~/app (alyx repo as compose source)

### DIFF
--- a/alyx/ansible/ansible_deploy_alyx.yaml
+++ b/alyx/ansible/ansible_deploy_alyx.yaml
@@ -1,0 +1,114 @@
+# Deploys/updates Alyx from the alyx-repo-sourced compose (cortex-lab/alyx deploy/app/).
+# Run this on the target server itself (see ansible_setup_alyx_server.yaml for one-time
+# host prep — swap, log dir, iblalyx clone — which must have already been run).
+#
+# ansible-playbook ansible_deploy_alyx.yaml -e alyx_hostname=alyx-test -e alyx_version=3.6.0
+#
+# alyx_hostname must match a directory under alyx/hosts/ in this iblsre checkout (the
+# one whose docker-compose.host.yaml, if any, applies to this server). alyx_version must
+# be a tag that exists on cortex-lab/alyx (e.g. a release version, or a `dev*` tag for a
+# preflight check against a candidate build).
+#
+# Populates ~/app (NOT a git checkout — plain files ansible manages) with:
+#   - docker-compose.yaml       fetched fresh from the alyx_version tag (source of truth)
+#   - template.env              fetched alongside it, for reference when merging .env
+#   - docker-compose.ibl.yaml   copied from this iblsre checkout (IBL-wide overlay)
+#   - docker-compose.host.yaml  copied from alyx/hosts/<alyx_hostname>/, if it exists
+# then ensures ~/app/.env's COMPOSE_FILE lists exactly the files present, so a plain
+# `docker compose up -d` in ~/app needs no `-f` flags. ~/app/.env itself is NOT managed
+# here — it must already exist (decrypted from the private ibldevtools sops copy) before
+# the first run.
+---
+- name: Deploy/update Alyx from the alyx-repo-sourced compose
+  hosts: localhost
+  become: yes
+  become_user: ubuntu
+  vars:
+    repo_dir: /home/ubuntu/Documents/PYTHON
+    app_dir: /home/ubuntu/app
+    alyx_raw_base: "https://raw.githubusercontent.com/cortex-lab/alyx/{{ alyx_version }}/deploy/app"
+    host_override_src: "{{ repo_dir }}/iblsre/alyx/hosts/{{ alyx_hostname }}/docker-compose.host.yaml"
+
+  tasks:
+    - name: Require alyx_hostname and alyx_version
+      assert:
+        that:
+          - alyx_hostname is defined
+          - alyx_version is defined
+        fail_msg: "Pass both -e alyx_hostname=<host> -e alyx_version=<tag>"
+
+    - name: Ensure ~/app exists
+      file:
+        path: "{{ app_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Fail fast if ~/app/.env is missing
+      stat:
+        path: "{{ app_dir }}/.env"
+      register: env_file
+
+    - name: Assert .env is present
+      assert:
+        that: env_file.stat.exists
+        fail_msg: >-
+          {{ app_dir }}/.env is missing. Decrypt this server's env from the private
+          ibldevtools/config/{{ alyx_hostname }}/ and place it there before deploying.
+
+    - name: Fetch the release's base compose + template.env from the alyx repo
+      get_url:
+        url: "{{ alyx_raw_base }}/{{ item }}"
+        dest: "{{ app_dir }}/{{ item }}"
+        mode: '0644'
+        force: yes
+      loop:
+        - docker-compose.yaml
+        - template.env
+
+    - name: Copy the IBL-wide overlay from this iblsre checkout
+      copy:
+        src: "{{ repo_dir }}/iblsre/alyx/containers/deploy-web/docker-compose.ibl.yaml"
+        dest: "{{ app_dir }}/docker-compose.ibl.yaml"
+        remote_src: yes
+        mode: '0644'
+
+    - name: Check whether this host has a host-specific override
+      stat:
+        path: "{{ host_override_src }}"
+      register: host_override
+
+    - name: Copy the host-specific override, if this host has one
+      copy:
+        src: "{{ host_override_src }}"
+        dest: "{{ app_dir }}/docker-compose.host.yaml"
+        remote_src: yes
+        mode: '0644'
+      when: host_override.stat.exists
+
+    - name: Remove a stale host override if this host no longer has one
+      file:
+        path: "{{ app_dir }}/docker-compose.host.yaml"
+        state: absent
+      when: not host_override.stat.exists
+
+    - name: Compute the COMPOSE_FILE list for this host
+      set_fact:
+        compose_files: >-
+          {{ (['docker-compose.yaml', 'docker-compose.ibl.yaml']
+              + (['docker-compose.host.yaml'] if host_override.stat.exists else [])) }}
+
+    - name: Ensure COMPOSE_FILE in .env matches the files actually present
+      lineinfile:
+        path: "{{ app_dir }}/.env"
+        regexp: '^COMPOSE_FILE='
+        line: "COMPOSE_FILE={{ compose_files | join(':') }}"
+
+    - name: Pull the new image
+      command: docker compose pull
+      args:
+        chdir: "{{ app_dir }}"
+
+    - name: Recreate containers that changed
+      command: docker compose up -d --remove-orphans
+      args:
+        chdir: "{{ app_dir }}"

--- a/alyx/containers/deploy-web/docker-compose.ibl.yaml
+++ b/alyx/containers/deploy-web/docker-compose.ibl.yaml
@@ -1,7 +1,11 @@
 # IBL-specific overlay on top of the generic alyx base compose (cortex-lab/alyx
 # deploy/app/docker-compose.yaml). Re-adds the iblalyx pieces that were removed from
-# the base compose so it stays server-agnostic. Apply with:
-#   docker compose -f <alyx>/deploy/app/docker-compose.yaml -f docker-compose.override.yaml up -d
+# the base compose so it stays server-agnostic.
+#
+# Deployed via `ansible_deploy_alyx.yaml`, which copies this file into the server's
+# ~/app directory and lists it in ~/app/.env's COMPOSE_FILE so a plain
+# `docker compose up -d` there picks it up automatically alongside the base compose
+# and (if present) docker-compose.host.yaml — no `-f` flags needed at deploy time.
 #
 # `command` fully replaces the base command (compose does not merge it), so it repeats
 # the base steps and prepends the iblalyx requirements install. The iblalyx/ibl_reports

--- a/alyx/hosts/alyx-test/docker-compose.host.yaml
+++ b/alyx/hosts/alyx-test/docker-compose.host.yaml
@@ -2,14 +2,11 @@
 #
 # alyx-test is an IBL server that serves ibl_reports, so it needs the iblalyx overlay
 # on top of the generic base compose. This file only adds the host-specific persistent
-# mounts; the iblalyx command + bind-mounts come from the shared overlay. Deploy by
-# stacking all three, base first:
+# mounts; the iblalyx command + bind-mounts come from docker-compose.ibl.yaml.
 #
-#   docker compose \
-#     -f <alyx>/deploy/app/docker-compose.yaml \
-#     -f <iblsre>/alyx/containers/deploy-web/docker-compose.override.yaml \
-#     -f <iblsre>/alyx/hosts/alyx-test/docker-compose.override.yaml \
-#     up -d
+# Deployed via `ansible_deploy_alyx.yaml -e alyx_hostname=alyx-test`, which copies this
+# file into ~/app and lists it in ~/app/.env's COMPOSE_FILE so a plain
+# `docker compose up -d` in ~/app picks up all three files — no `-f` flags needed.
 #
 # Requires iblalyx cloned on the host (ansible_setup_alyx_server.yaml does this, to
 # /home/ubuntu/iblalyx) so the overlay's bind-mount has a source.

--- a/alyx/hosts/cortexlab/docker-compose.host.yaml
+++ b/alyx/hosts/cortexlab/docker-compose.host.yaml
@@ -1,6 +1,9 @@
 # Cortexlab overlay on top of the generic alyx base compose
 # (cortex-lab/alyx deploy/app/docker-compose.yaml).
 #
+# Deployed via `ansible_deploy_alyx.yaml -e alyx_hostname=cortexlab`, which copies this
+# file into ~/app and lists it in ~/app/.env's COMPOSE_FILE for a plain `docker compose up -d`.
+#
 # Differences from the base:
 #   - installs django_ses (email via AWS SES) at startup;
 #   - mounts the lab-specific settings_lab.py (kept sops-encrypted in the private

--- a/alyx/hosts/steinmetzlab/docker-compose.host.yaml
+++ b/alyx/hosts/steinmetzlab/docker-compose.host.yaml
@@ -1,6 +1,9 @@
 # Steinmetzlab overlay on top of the generic alyx base compose
 # (cortex-lab/alyx deploy/app/docker-compose.yaml).
 #
+# Deployed via `ansible_deploy_alyx.yaml -e alyx_hostname=steinmetzlab`, which copies this
+# file into ~/app and lists it in ~/app/.env's COMPOSE_FILE for a plain `docker compose up -d`.
+#
 # Only difference from the base: mounts the lab-specific settings_lab.py (kept
 # sops-encrypted in the private ibldevtools/config/alyx-steinmetzlab/; decrypt it to
 # ALYX_SETTINGS_LAB on the host). Inherits the base startup command unchanged.


### PR DESCRIPTION
## Summary
- Adds `alyx/ansible/ansible_deploy_alyx.yaml`: fetches the release's `docker-compose.yaml` + `template.env` straight from the `cortex-lab/alyx` tag into a plain, ansible-managed `~/app` directory (not a git checkout — avoids the "looks like a repo but isn't" confusion), copies in the IBL overlay + any host override from this iblsre checkout, and keeps `~/app/.env`'s `COMPOSE_FILE` in sync so `docker compose up -d` needs no `-f` flags.
- Renames `docker-compose.override.yaml` -> `docker-compose.ibl.yaml` (shared IBL overlay) and `docker-compose.host.yaml` (per-host), to match the `COMPOSE_FILE` naming and avoid colliding with Compose's own auto-discovered override filename.
- Not yet validated end-to-end — first live run planned against alyx-test.

## Test plan
- [ ] `ansible-playbook ansible_deploy_alyx.yaml -e alyx_hostname=alyx-test -e alyx_version=3.6.0` on alyx-test
- [ ] Verify `~/app/.env` COMPOSE_FILE line, `docker compose up -d` with no `-f` flags
- [ ] Verify ibl_reports renders and the tables cache persists across a container restart